### PR TITLE
Fix possible return value of `Customer::getProfilingConsent()`

### DIFF
--- a/src/Model/Customer.php
+++ b/src/Model/Customer.php
@@ -20,11 +20,8 @@ use CustomerManagementFrameworkBundle\Model\SsoAwareCustomerInterface;
 
 class Customer extends \Pimcore\Model\DataObject\Customer implements SsoAwareCustomerInterface, PasswordRecoveryInterface
 {
-    /**
-     * @return bool
-     */
     public function getProfilingConsent(): ?\Pimcore\Model\DataObject\Data\Consent
     {
-        return $this->getProfiling() ? $this->getProfiling()->getConsent() : false;
+        return $this->getProfiling() ? $this->getProfiling()->getConsent() : null;
     }
 }


### PR DESCRIPTION
#268 changed the return type, so `false` is not allowed anymore as return value.