### PR TITLE
Include user id in docker setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,17 @@ You don't need to have a PHP environment with composer installed.
 ### Follow these steps
 
 1. Initialize the demo project using the `pimcore/pimcore` image
-    ``docker run --rm -v `pwd`:/var/www/html pimcore/pimcore:PHP8.0-fpm composer create-project pimcore/demo my-project``
-1. Fix permissions of the created directory (we are already working on a fix to make this redundant)
-    `sudo chown -R 1000 my-project/`
+    ``docker run -u `id -u`:`id -g` --rm -v `pwd`:/var/www/html pimcore/pimcore:PHP8.0-fpm composer create-project pimcore/demo my-project``
 1. Go to your new project
     `cd my-project/`
-1. Part of the new project is a docker compose file. Use it to start the needed services
-    `docker-compose up -d`
+1. Part of the new project is a docker compose file
+    * Run `` echo `id -u`:`id -g` `` to retrieve your local user and group id
+    * Open the `docker-compose.yml` file in an editor, uncomment all the `user: '1000:1000'` lines and update the ids if necessary
+    * Start the needed services with `docker-compose up -d`
 1. Install pimcore and initialize the DB
     `docker-compose exec php-fpm vendor/bin/pimcore-install --mysql-host-socket=db --mysql-username=pimcore --mysql-password=pimcore --mysql-database=pimcore`
     * When asked for admin user and password: Choose freely
     * This can take a while, up to 20 minutes
-1. Fix permissions again, the installer has created new directories
-    `docker-compose run --rm php-fpm chown -R www-data:www-data var/*`
 1. :heavy_check_mark: DONE - You can now visit your pimcore-demo:
     * The frontend: <http://localhost>
     * The admin interface, using the credentials you have chosen above:


### PR DESCRIPTION
- The setup steps were missing the step to update docker-compose.yml and uncomment the user id lines (introduced in 2206ad0e757b01d86589e9fd7e134a142b12a93d )
- Updated the docker-compose run/exec commands to run with user's id so a manual chown afterwards isn't necessary anymore