### PR TITLE
Don't import the `services.yaml` in the `config.yaml`

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,5 +1,4 @@
 imports:
-    - { resource: services.yaml }
     - { resource: 'local/' }
     - { resource: ecommerce/base-ecommerce.yaml }
     - { resource: cmf.yaml }


### PR DESCRIPTION
It already gets imported via the [`Kernel`](https://github.com/pimcore/pimcore/blob/9d82ae1a5c5806406344d75445b3d3a1f8adb47e/lib/Kernel.php#L123-L125) (after the config was loaded).

See pimcore/skeleton#78