### PR TITLE
[Task]: Changed Pimcore requirement (back) to 10.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "php-http/guzzle7-adapter": "^0.1.1",
     "php-http/httplug-bundle": "^1",
     "pimcore/customer-management-framework-bundle": "^3.0",
-    "pimcore/pimcore": "^10.4",
+    "pimcore/pimcore": "^10.x-dev",
     "pimcore/web2print-tools-bundle": "^4.0",
     "pimcore/data-hub": "^1.0",
     "pimcore/payment-provider-paypal-smart-payment-button": "^1.0"


### PR DESCRIPTION
Since demo has now 2 branches in demo, the composer requirement on the 10.x branch can be changed to `10.x-dev`