### PR TITLE
Set PHP_IDE_CONFIG env variable without quotes

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,7 +41,7 @@ services:
         #user: '1000:1000' # set to your uid:gid
         image: pimcore/pimcore:PHP8.1-fpm-debug
         environment:
-            PHP_IDE_CONFIG: "serverName=localhost"
+            PHP_IDE_CONFIG: serverName=localhost
             COMPOSER_HOME: /var/www/html
         depends_on:
             - db


### PR DESCRIPTION
See https://github.com/pimcore/skeleton/blob/e2e27dac7bf295e1f2dadda25d3f7869d97dd821/docker-compose.yaml#L49
With the quotes you will have the behaviour as described in https://stackoverflow.com/questions/50155844/cannot-parse-server-name-for-external-xdebug-connection