### PR TITLE
[Task]: Whitelist m4a file format in docker nginx conf

### DIFF
--- a/.docker/nginx.conf
+++ b/.docker/nginx.conf
@@ -104,7 +104,7 @@ server {
 
     # Assets
     # Still use a whitelist approach to prevent each and every missing asset to go through the PHP Engine.
-    location ~* ^(?!/admin)(.+?)\.((?:css|js)(?:\.map)?|jpe?g|gif|png|svgz?|eps|exe|gz|zip|mp\d|ogg|ogv|webm|pdf|docx?|xlsx?|pptx?)$ {
+    location ~* ^(?!/admin)(.+?)\.((?:css|js)(?:\.map)?|jpe?g|gif|png|svgz?|eps|exe|gz|zip|mp\d|m4a|ogg|ogv|webm|pdf|docx?|xlsx?|pptx?)$ {
         try_files /var/assets$uri $uri =404;
         expires 2w;
         access_log off;


### PR DESCRIPTION
I've faced a problem when trying to play m4a files while on nginx and it seems that it need to be whitelisted.
So adapting the docker .nginx file here to match the documetend one

Please see: https://github.com/pimcore/pimcore/pull/12841#issuecomment-1208241344