### PR TITLE
[Task]: Switch to pimcore_glossary twig filter

### DIFF
--- a/templates/areas/wysiwyg-with-images/view.html.twig
+++ b/templates/areas/wysiwyg-with-images/view.html.twig
@@ -10,9 +10,9 @@
 <section class="area-wysiwyg">
     <div class="row">
         <div class="col-sm-8">
-            {% pimcoreglossary %}
+            {% apply pimcore_glossary %}
                 {{ content|raw }}
-            {% endpimcoreglossary %}
+            {% endapply %}
         </div>
         <div class="col-sm-4">
             {% for i in pimcore_iterate_block(pimcore_block('images')) %}

--- a/templates/areas/wysiwyg/view.html.twig
+++ b/templates/areas/wysiwyg/view.html.twig
@@ -6,7 +6,7 @@
 {% endif %}
 
 <section class="area-wysiwyg">
-    {% pimcoreglossary %}
+    {% apply pimcore_glossary %}
         {{ content|raw }}
-    {% endpimcoreglossary %}
+    {% endapply %}
 </section>


### PR DESCRIPTION
Opened as a task, in preparation for pimcoreglossary() removal in 11.x and because it's deprecated since 10.1
See also https://github.com/pimcore/pimcore/issues/12927