### PR TITLE
[Bug]: Fix invalid height value in Video Editable template

### DIFF
--- a/templates/areas/video/view.html.twig
+++ b/templates/areas/video/view.html.twig
@@ -6,7 +6,7 @@
                 'data-setup': '{}'
             },
             thumbnail: 'content',
-            height: 'auto'
+            height: '100%'
         })
     }}
 </section>


### PR DESCRIPTION
Requires https://github.com/pimcore/pimcore/pull/13511

Height can only be either[ pixel or percent](https://github.com/pimcore/pimcore/blob/747b0d7761fdd8a933de5fdd8e3a7990336589e2/doc/Development_Documentation/03_Documents/01_Editables/38_Video.md?plain=1#L16) but only px where supported 


More details on https://github.com/pimcore/pimcore/pull/13511