### PR TITLE
[Task] Adding post installation check

### DIFF
--- a/.github/workflows/pimcore-demo.yml
+++ b/.github/workflows/pimcore-demo.yml
@@ -89,3 +89,14 @@ jobs:
         -e PIMCORE_INSTALL_MYSQL_PASSWORD=pimcore \
         -- \
         php vendor/bin/pimcore-install -n --mysql-host-socket=db --mysql-database=pimcore
+          
+        # Change owner  
+        sudo chown -R www-data .  
+        
+        # Check if website is reachable
+        response=$(docker-compose exec -T -- php bash -c 'curl -s "nginx:80"')
+        
+        if [[ ! $response =~ "Satisfaction" ]]; then
+           echo "Install failed, skipping build"
+           exit 1;
+        fi


### PR DESCRIPTION
related to https://github.com/pimcore/demo-enterprise/issues/84

## Additional Info
Adding curl call to nginx after installation so check if the website is available and working.

Output of $response could not be reproduced on other bash. Every bash is different. Did not find a way to suppress this. Maybe we need a custom runner at some point anyways.