### PR TITLE
[Task]: Prioritize EcommerceFrameworkBundle over PersonalizationBundle

### DIFF
--- a/config/bundles.php
+++ b/config/bundles.php
@@ -18,6 +18,7 @@ use Pimcore\Bundle\PersonalizationBundle\PimcorePersonalizationBundle;
 
 return [
     //Twig\Extra\TwigExtraBundle\TwigExtraBundle::class => ['all' => true],
+    PimcoreEcommerceFrameworkBundle::class => ['all' => true],
     PimcorePersonalizationBundle::class => ['all' => true],
     PimcoreCustomerManagementFrameworkBundle::class => ['all' => true],
     PimcoreGlossaryBundle::class => ['all' => true],
@@ -32,5 +33,4 @@ return [
     PimcoreGoogleMarketingBundle::class => ['all' => true],
     PimcoreApplicationLoggerBundle::class => ['all' => true],
     PimcoreWebToPrintBundle::class => ['all' => true],
-    PimcoreEcommerceFrameworkBundle::class => ['all' => true],
 ];


### PR DESCRIPTION
Prior this PR, it crashes as 
![image](https://user-images.githubusercontent.com/6014195/223206085-a3cb95ef-91b1-4045-9e54-3ade22936f42.png)
![image](https://user-images.githubusercontent.com/6014195/223206122-7a62b3e1-596e-4862-815b-1dff3bc13993.png)
because `pimcore.bundle.EcommerceFramework.pricing` is not yet initialized.


The actual solution should be setting some priority and/or check if that bundle is present before loading that etc..