### PR TITLE
[Bug]: Limit password length

### DIFF
--- a/src/Controller/AccountController.php
+++ b/src/Controller/AccountController.php
@@ -17,6 +17,7 @@ namespace App\Controller;
 
 use App\EventListener\AuthenticationLoginListener;
 use App\Form\LoginFormType;
+use App\Form\PasswordMaxLengthTrait;
 use App\Form\RegistrationFormHandler;
 use App\Form\RegistrationFormType;
 use App\Model\Customer;
@@ -54,6 +55,7 @@ use Symfony\Component\Uid\Uuid;
  */
 class AccountController extends BaseController
 {
+    use PasswordMaxLengthTrait;
     /**
      * @Route("/account/login", name="account-login")
      *
@@ -213,6 +215,10 @@ class AccountController extends BaseController
             $customer->setActive(true);
 
             try {
+                if(!$hidePassword) {
+                    $this->checkPassword($form->getData()['password']);
+                }
+
                 $customer->save();
 
                 if ($form->getData()['newsletter']) {
@@ -509,24 +515,35 @@ class AccountController extends BaseController
     {
         $token = $request->get('token');
         $customer = $service->getCustomerByToken($token);
-        if (!$customer) {
-            //TODO render error page
-            throw new NotFoundHttpException('Invalid token');
-        }
+        $error = null;
+        try {
+            if (!$customer) {
+                throw new NotFoundHttpException('Invalid token');
+            }
 
-        if ($request->isMethod(Request::METHOD_POST)) {
-            $newPassword = $request->get('password');
-            $service->setPassword($token, $newPassword);
+            if ($request->isMethod(Request::METHOD_POST)) {
 
-            $this->addFlash('success', $translator->trans('account.password-reset-successful'));
+                $newPassword = $request->get('password');
 
-            return $this->redirectToRoute('account-login', ['no-referer-redirect' => true]);
+                $this->checkPassword($newPassword);
+
+                $service->setPassword($token, $newPassword);
+
+                $this->addFlash('success', $translator->trans('account.password-reset-successful'));
+
+                return $this->redirectToRoute('account-login', ['no-referer-redirect' => true]);
+
+            }
+
+        } catch (\Exception $exception) {
+            $error = $exception->getMessage();
         }
 
         return $this->render('account/reset_password.html.twig', [
             'hideBreadcrumbs' => true,
             'token' => $token,
-            'email' => $customer->getEmail()
+            'email' => $customer?->getEmail(),
+            'error' => $error
         ]);
     }
 }

--- a/src/Form/LoginFormType.php
+++ b/src/Form/LoginFormType.php
@@ -36,6 +36,7 @@ use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 
 class LoginFormType extends AbstractType
 {
@@ -55,6 +56,9 @@ class LoginFormType extends AbstractType
                 'label' => 'user.password',
                 'label_attr' => [
                     'class' => 'sr-only'
+                ],
+                'attr' => [
+                    'maxlength' => PasswordHasherInterface::MAX_PASSWORD_LENGTH
                 ]
             ])
             ->add('_target_path', HiddenType::class)

--- a/src/Form/PasswordMaxLengthTrait.php
+++ b/src/Form/PasswordMaxLengthTrait.php
@@ -31,7 +31,7 @@ trait PasswordMaxLengthTrait
     public function checkPassword(string $password): void
     {
         if ($this->isPasswordTooLong($password)) {
-            throw new ValidationException("Given Password is to long.");
+            throw new ValidationException("Given password is too long.");
         }
     }
 }

--- a/src/Form/PasswordMaxLengthTrait.php
+++ b/src/Form/PasswordMaxLengthTrait.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ * @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ * @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+
+namespace App\Form;
+
+use Pimcore\Model\Element\ValidationException;
+use Symfony\Component\PasswordHasher\Hasher\CheckPasswordLengthTrait;
+
+trait PasswordMaxLengthTrait
+{
+    use CheckPasswordLengthTrait;
+
+    /**
+     * @throws ValidationException
+     */
+    public function checkPassword(string $password): void
+    {
+        if ($this->isPasswordTooLong($password)) {
+            throw new ValidationException("Given Password is to long.");
+        }
+    }
+}

--- a/src/Form/RegistrationFormType.php
+++ b/src/Form/RegistrationFormType.php
@@ -38,6 +38,7 @@ use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\PasswordHasher\PasswordHasherInterface;
 
 class RegistrationFormType extends AbstractType
 {
@@ -61,7 +62,10 @@ class RegistrationFormType extends AbstractType
             ]);
         if (!$options['hidePassword']) {
             $builder->add('password', PasswordType::class, [
-                'label' => 'general.password'
+                'label' => 'general.password',
+                'attr' => [
+                    'maxlength' => PasswordHasherInterface::MAX_PASSWORD_LENGTH
+                ]
             ]);
         }
 

--- a/templates/account/reset_password.html.twig
+++ b/templates/account/reset_password.html.twig
@@ -8,6 +8,11 @@
         <div class="form-signin mb-5">
 
             <form method="post">
+                {% if error %}
+                    <div class="alert alert-danger">
+                        {{ error | raw }}
+                    </div>
+                {% else %}
                 <h1 class="display-3 mb-3 font-weight-normal">{{ 'account.password-recovery' | trans }}</h1>
 
                 <p>{{ 'account.password-recovery-text' | trans([email]) }}</p>
@@ -17,6 +22,7 @@
                 <div class="form-group">
                     <button type="submit" id="_submit" name="_submit" class="btn-success btn-lg btn-block mt-4 btn">{{ 'account.set-password' | trans }}</button>
                 </div>
+                {% endif %}
 
             </form>
 


### PR DESCRIPTION
Resolves #422

## Additional Info
 - Restrict password length using Symfony `isPasswordTooLong()` method.
 - Added page to password_reset.
 - Login should already be handled by Symfony.
 - Added Frontend check as well. 
