### PR TITLE
[Task]: Fix regression Newsletter news

### DIFF
--- a/src/Controller/NewsController.php
+++ b/src/Controller/NewsController.php
@@ -89,8 +89,8 @@ class NewsController extends BaseController
     public function emailNewsTeaserAction(Request $request, NewsLinkGenerator $newsLinkGenerator): Response
     {
         $paramsBag = [];
-        if ($request->attributes->get('type') === 'object') {
-            $news = News::getById($request->attributes->getInt('id'));
+        if ($request->query->get('type') === 'object') {
+            $news = News::getById($request->query->getInt('id'));
             $paramsBag['news'] = $news;
             $paramsBag['detailLink'] = $newsLinkGenerator->generate($news, ['document' => $this->document->getProperty('news_default_document')]);
 

--- a/src/Controller/NewsController.php
+++ b/src/Controller/NewsController.php
@@ -89,8 +89,8 @@ class NewsController extends BaseController
     public function emailNewsTeaserAction(Request $request, NewsLinkGenerator $newsLinkGenerator): Response
     {
         $paramsBag = [];
-        if ($request->query->get('type') === 'object') {
-            $news = News::getById($request->query->getInt('id'));
+        if ($request->get('type') === 'object') {
+            $news = News::getById($request->get('id'));
             $paramsBag['news'] = $news;
             $paramsBag['detailLink'] = $newsLinkGenerator->generate($news, ['document' => $this->document->getProperty('news_default_document')]);
 

--- a/src/Controller/NewsController.php
+++ b/src/Controller/NewsController.php
@@ -76,8 +76,8 @@ class NewsController extends BaseController
     public function newsTeaserAction(Request $request): Response
     {
         $paramsBag = [];
-        if ($request->attributes->get('type') === 'object') {
-            $news = News::getById($request->attributes->getInt('id'));
+        if ($request->get('type') === 'object') {
+            $news = News::getById($request->get('id'));
             $paramsBag['news'] = $news;
 
             return $this->render('news/news_teaser.html.twig', $paramsBag);


### PR DESCRIPTION
Follow-up https://github.com/pimcore/demo/pull/389

In the current PR, i am fixing the case i've encountered by reverting that change.
A TODO would be re-review https://github.com/pimcore/demo/pull/389 and see if all the other changes are affecting too

It seems that the editable would work when set to `$request->query` instead of `$request->attributes` but breaks the email (by looking at email sent) and viceversa.

![image](https://user-images.githubusercontent.com/6014195/230349576-bd476832-8c73-42c0-af5a-dae4c21cb385.png)
![image](https://user-images.githubusercontent.com/6014195/230349863-d1af58b8-d227-4a0c-a79b-ecc6ec303dfc.png)
![image](https://user-images.githubusercontent.com/6014195/230351714-d7127d3c-dcfa-46b6-ad77-8b84eb4f993c.png)



