### PR TITLE
Remove `AbstractSsoIdentity` as parentClass

### DIFF
--- a/var/classes/definition_SsoIdentity.php
+++ b/var/classes/definition_SsoIdentity.php
@@ -20,7 +20,7 @@ return Pimcore\Model\DataObject\ClassDefinition::__set_state(array(
    'modificationDate' => 1665067175,
    'userOwner' => 0,
    'userModification' => 1,
-   'parentClass' => '\\CustomerManagementFrameworkBundle\\Model\\AbstractSsoIdentity',
+   'parentClass' => '',
    'implementsInterfaces' => '',
    'listingParentClass' => '',
    'useTraits' => '',


### PR DESCRIPTION
Remove `AbstractSsoIdentity` as parent class of `SsoIdentity`

Since `composer.json` requires `customer-data-framework: ^4.0` we cant use the `AbstractSsoIdentity anymore` (it was removed in 4.0)

https://github.com/pimcore/demo/blob/8b8e43cc45e16c350ae82d86bf498b7f1e31d531/composer.json#L21