### PR TITLE
[Bug]: Use `useridentifier` instead of deprecated `username`

### DIFF
--- a/templates/includes/navigation-icons.html.twig
+++ b/templates/includes/navigation-icons.html.twig
@@ -12,7 +12,7 @@
 
                 <span class="dropdown-menu-arrow search arrow"></span>
 
-                <div class="dropdown-item">{{ 'general.logged-in-as' | trans([app.user.username]) }}</div>
+                <div class="dropdown-item">{{ 'general.logged-in-as' | trans([app.user.useridentifier]) }}</div>
                 <div class="dropdown-divider"></div>
                 <a href="{{ path('account-index') }}" class="dropdown-item">{{ 'general.profile' | trans }}</a>
                 <div class="dropdown-divider"></div>


### PR DESCRIPTION
This line causes the XLIFF Document Export to crash

`Uncaught PHP Exception Twig\Error\RuntimeError: "Neither the property "username" nor one of the methods "username()", "getusername()"/"isusername()"/"hasusername()" or "__call()" exist and have public access in class "Pimcore\Security\User\User"." at /var/www/html/templates/includes/navigation-icons.html.twig line 15 {"exception":"[object] (Twig\\Error\\RuntimeError(code: 0): Neither the property \"username\" nor one of the methods \"username()\", \"getusername()\"/\"isusername()\"/\"hasusername()\" or \"__call()\" exist and have public access in class \"Pimcore\\Security\\User\\User\". at /var/www/html/templates/includes/navigation-icons.html.twig:15)"} []`

It's safer to use `useridentifier`
See also https://symfony.com/blog/new-in-symfony-5-3-improvements-for-security-users#renamed-username-to-identifier

Not sure why it works when normally browsing but not when trying to renderDocuments and export 