### PR TITLE
Update PimcoreUrl.php

### DIFF
--- a/src/Website/Tool/PimcoreUrl.php
+++ b/src/Website/Tool/PimcoreUrl.php
@@ -30,7 +30,7 @@ class PimcoreUrl extends \Pimcore\Twig\Extension\Templating\PimcoreUrl
     {
         // merge all parameters from request to parameters
         if (!$reset && $this->requestHelper->hasMainRequest()) {
-            $urlOptions = array_replace($this->requestHelper->getMainRequest()->attributes->get('_route_params'), $urlOptions);
+            $urlOptions = array_replace($this->requestHelper->getMainRequest()->attributes->get('_route_params', []), $urlOptions);
         }
 
         return parent::__invoke($urlOptions, $name, $reset, $encode, $relative);


### PR DESCRIPTION
Rebased https://github.com/pimcore/demo/pull/518 for Pimcore 10 demo as well

Check if $this->requestHelper->getMainRequest()->attributes->get('_route_params') does not return null and if so, set it to an empty array. It this case occurs, the routing leads to some errors, in my case it was not possible to use the default error page mechanism from pimcore, i always got an error 500.