### PR TITLE
[Bug]: Fix language switcher

### DIFF
--- a/src/Twig/Extension/LanguageSwitcherExtension.php
+++ b/src/Twig/Extension/LanguageSwitcherExtension.php
@@ -38,18 +38,13 @@ class LanguageSwitcherExtension extends AbstractExtension implements ServiceSubs
      */
     private $documentService;
 
-    /**
-     * @var UrlGeneratorInterface $urlGenerator
-     */
     private UrlGeneratorInterface $urlGenerator;
-
-    /**
-     * @var RequestStack $requestStack
-     */
     private RequestStack $requestStack;
-
-    public function __construct(private ContainerInterface $locator, Service $documentService, UrlGeneratorInterface $urlGenerator, RequestStack $requestStack)
+    private ContainerInterface $locator;
+    
+    public function __construct(ContainerInterface $locator, Service $documentService, UrlGeneratorInterface $urlGenerator, RequestStack $requestStack)
     {
+        $this->locator = $locator;
         $this->documentService = $documentService;
         $this->urlGenerator = $urlGenerator;
         $this->requestStack = $requestStack;

--- a/src/Twig/Extension/LanguageSwitcherExtension.php
+++ b/src/Twig/Extension/LanguageSwitcherExtension.php
@@ -71,9 +71,9 @@ class LanguageSwitcherExtension extends AbstractExtension
             }
 
             $route = $request->get('_route');
-            $routeParams = $request->get('_route_params');
+            $routeParams = $request->get('_route_params', []);
 
-            if ($route && count($routeParams ?? []) > 1) {
+            if ($route && count($routeParams) > 1) {
                 $routeParams['_locale'] = \Locale::getPrimaryLanguage($language);
                 $target = $this->urlGenerator->generate($route, $routeParams);
             }

--- a/src/Twig/Extension/LanguageSwitcherExtension.php
+++ b/src/Twig/Extension/LanguageSwitcherExtension.php
@@ -73,10 +73,9 @@ class LanguageSwitcherExtension extends AbstractExtension
             $route = $request->get('_route');
             $routeParams = $request->get('_route_params');
 
-            if ($route && $routeParams) {
+            if ($route && count($routeParams ?? []) > 1) {
                 $routeParams['_locale'] = \Locale::getPrimaryLanguage($language);
-                $route = $this->urlGenerator->generate($route, $routeParams);
-                $target = $route;
+                $target = $this->urlGenerator->generate($route, $routeParams);
             }
 
             $links[$language] = [

--- a/src/Twig/Extension/LanguageSwitcherExtension.php
+++ b/src/Twig/Extension/LanguageSwitcherExtension.php
@@ -104,15 +104,20 @@ class LanguageSwitcherExtension extends AbstractExtension implements ServiceSubs
 
             if ($route && array_key_exists($route, $dynamicRoutesMapping)) {
                 $routeParams = $request->get('_route_params', []);
-                $routeParams['locale'] = $routeParams['_locale'] = \Locale::getPrimaryLanguage($language);
+                $requiredField = $dynamicRoutesMapping[$route]['requiredField'];
+
+                if (!array_key_exists($requiredField, $routeParams)){
+                    continue;
+                }
 
                 $generator = $dynamicRoutesMapping[$route]['generator'];
-                $object = $request->get($dynamicRoutesMapping[$route]['requiredField']);
+                $object = $request->get($requiredField);
+
                 if (!is_object($object)) {
                     $object = DataObject::getById($object);
                 }
                 $linkGeneratorService = $this->locator->get($generator);
-                $target = $linkGeneratorService->generate($object, $routeParams);
+                $target = $linkGeneratorService->generate($object, ['locale' => \Locale::getPrimaryLanguage($language)]);
             }
 
             $links[$language] = [

--- a/src/Website/LinkGenerator/AbstractProductLinkGenerator.php
+++ b/src/Website/LinkGenerator/AbstractProductLinkGenerator.php
@@ -59,7 +59,7 @@ abstract class AbstractProductLinkGenerator implements LinkGeneratorInterface
      * @param Category|null $rootCategory
      * @return string
      */
-    public function getNavigationPath(?Category $category, ?Category $rootCategory = null)
+    public function getNavigationPath(?Category $category, ?Category $rootCategory = null, $locale = null)
     {
         if (empty($rootCategory)) {
             if (!$this->document) {
@@ -83,7 +83,7 @@ abstract class AbstractProductLinkGenerator implements LinkGeneratorInterface
         }
 
         foreach ($categories as $categoryInPath) {
-            $path .= Text::toUrl($categoryInPath->getName()).'/';
+            $path .= Text::toUrl($categoryInPath->getName($locale)).'/';
         }
 
         return $path;

--- a/src/Website/LinkGenerator/CategoryLinkGenerator.php
+++ b/src/Website/LinkGenerator/CategoryLinkGenerator.php
@@ -44,7 +44,7 @@ class CategoryLinkGenerator extends AbstractProductLinkGenerator implements Link
 
         return $this->pimcoreUrl->__invoke(
             [
-                'categoryname' => Text::toUrl($object->getName() ? $object->getName() : 'elements'),
+                'categoryname' => Text::toUrl($object->getName($locale) ? $object->getName($locale) : 'elements'),
                 'category' => $object->getId(),
                 'path' => $this->getNavigationPath($object, $params['rootCategory'] ?? null, $locale),
                 'page' => null,

--- a/src/Website/LinkGenerator/CategoryLinkGenerator.php
+++ b/src/Website/LinkGenerator/CategoryLinkGenerator.php
@@ -40,12 +40,15 @@ class CategoryLinkGenerator extends AbstractProductLinkGenerator implements Link
             $this->document = $params['document'];
         }
 
+        $locale = $params['locale'] ?? null;
+
         return $this->pimcoreUrl->__invoke(
             [
                 'categoryname' => Text::toUrl($object->getName() ? $object->getName() : 'elements'),
                 'category' => $object->getId(),
-                'path' => $this->getNavigationPath($object, $params['rootCategory'] ?? null),
-                'page' => null
+                'path' => $this->getNavigationPath($object, $params['rootCategory'] ?? null, $locale),
+                'page' => null,
+                '_locale' => $locale,
             ],
             'shop-category',
             $reset

--- a/src/Website/LinkGenerator/NewsLinkGenerator.php
+++ b/src/Website/LinkGenerator/NewsLinkGenerator.php
@@ -94,11 +94,14 @@ class NewsLinkGenerator implements LinkGeneratorInterface
                 $fullPath = $document->getProperty('news_default_document') ? substr($document->getProperty('news_default_document')->getFullPath(), strlen($localeUrlPart)) : '';
             }
 
+            $locale = $params['locale'] ?? null;
+
             return $this->pimcoreUrl->__invoke(
                 [
                 'newstitle' => Text::toUrl($object->getTitle() ? $object->getTitle() : 'news'),
                 'news' => $object->getId(),
-                'path' => $fullPath
+                'path' => $fullPath,
+                '_locale' => $locale,
             ],
                 'news-detail',
                 true

--- a/src/Website/LinkGenerator/NewsLinkGenerator.php
+++ b/src/Website/LinkGenerator/NewsLinkGenerator.php
@@ -98,7 +98,7 @@ class NewsLinkGenerator implements LinkGeneratorInterface
 
             return $this->pimcoreUrl->__invoke(
                 [
-                'newstitle' => Text::toUrl($object->getTitle() ? $object->getTitle() : 'news'),
+                'newstitle' => Text::toUrl($object->getTitle($locale) ? $object->getTitle($locale) : 'news'),
                 'news' => $object->getId(),
                 'path' => $fullPath,
                 '_locale' => $locale,

--- a/src/Website/LinkGenerator/ProductLinkGenerator.php
+++ b/src/Website/LinkGenerator/ProductLinkGenerator.php
@@ -69,12 +69,15 @@ class ProductLinkGenerator extends AbstractProductLinkGenerator implements LinkG
                 return current($object->getUrlSlug())->getSlug();
             }
 
+            $locale = $params['locale'] ?? null;
+
             return $this->pimcoreUrl->__invoke(
                 [
                     'productname' => Text::toUrl($object->getOSName() ?? 'product'),
                     'product' => $object->getId(),
-                    'path' => $this->getNavigationPath($object->getMainCategory(), $params['rootCategory'] ?? null),
-                    'page' => null
+                    'path' => $this->getNavigationPath($object->getMainCategory(), $params['rootCategory'] ?? null, $locale),
+                    'page' => null,
+                    '_locale' => $locale,
                 ],
                 'shop-detail',
                 true


### PR DESCRIPTION
Resolves https://github.com/pimcore/demo/issues/517

Previously when trying to switch language on any static routes, it would just redirect to home page of the selected language.
An attempt to fix it was provided on https://github.com/pimcore/demo/pull/435 but it caused to stop working on normal documents.
This PR provides the fix and also returns the translated slugs (which 435 did only prepend the `/de` and `/en`)
