### PR TITLE
[Bug]: Fix wrong class to be checked when switching language with LinkGenerator

### DIFF
--- a/src/Twig/Extension/LanguageSwitcherExtension.php
+++ b/src/Twig/Extension/LanguageSwitcherExtension.php
@@ -107,7 +107,7 @@ class LanguageSwitcherExtension extends AbstractExtension
                 }
                 
                 $linkGeneratorService = $this->$generator;
-                if ($linkGeneratorService instanceof AbstractProductLinkGenerator) {
+                if ($linkGeneratorService instanceof LinkGeneratorInterface) {
                     $target = $linkGeneratorService->generate($object, ['locale' => \Locale::getPrimaryLanguage($language)]);
                 }
             }


### PR DESCRIPTION
Follow up https://github.com/pimcore/demo/pull/524

AbstractProductLinkGenerator is used in CategoryLink and ProductLink but not NewsLink