### PR TITLE
Consistently use "utf8mb4_general_ci" as database collation

### DIFF
--- a/.github/ci/files/docker-compose.yaml
+++ b/.github/ci/files/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
     db:
         image: ${DOCKER_DATABASE}
         working_dir: /application
-        command: [ mysqld, --log_bin_trust_function_creators=1, --character-set-server=utf8mb4, --collation-server=utf8mb4_unicode_ci, --innodb-file-per-table=1 ]
+        command: [ mysqld, --log_bin_trust_function_creators=1, --character-set-server=utf8mb4, --collation-server=utf8mb4_general_ci, --innodb-file-per-table=1 ]
         volumes:
             - pimcore-demo-database:/var/lib/mysql
         environment:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
     db:
         image: mariadb:10.11
         working_dir: /application
-        command: [ mysqld, --character-set-server=utf8mb4, --collation-server=utf8mb4_unicode_ci, --innodb-file-per-table=1 ]
+        command: [ mysqld, --character-set-server=utf8mb4, --collation-server=utf8mb4_general_ci, --innodb-file-per-table=1 ]
         volumes:
             - pimcore-demo-database:/var/lib/mysql
         environment:


### PR DESCRIPTION
@see: https://github.com/pimcore/pimcore/pull/16080