### PR TITLE
Remove unused permissions tag_snippet_management and piwik_ from User Permissions

### DIFF
--- a/dump/data-1-users_permission_definitions.sql
+++ b/dump/data-1-users_permission_definitions.sql
@@ -56,7 +56,6 @@ INSERT INTO users_permission_definitions (`key`,`category`) VALUES ('system_sett
 INSERT INTO users_permission_definitions (`key`,`category`) VALUES ('tags_assignment','');
 INSERT INTO users_permission_definitions (`key`,`category`) VALUES ('tags_configuration','');
 INSERT INTO users_permission_definitions (`key`,`category`) VALUES ('tags_search','');
-INSERT INTO users_permission_definitions (`key`,`category`) VALUES ('tag_snippet_management','');
 INSERT INTO users_permission_definitions (`key`,`category`) VALUES ('targeting','Pimcore Personalization Bundle');
 INSERT INTO users_permission_definitions (`key`,`category`) VALUES ('thumbnails','');
 INSERT INTO users_permission_definitions (`key`,`category`) VALUES ('translations','');

--- a/dump/data-1-users_permission_definitions.sql
+++ b/dump/data-1-users_permission_definitions.sql
@@ -28,8 +28,6 @@ INSERT INTO users_permission_definitions (`key`,`category`) VALUES ('notificatio
 INSERT INTO users_permission_definitions (`key`,`category`) VALUES ('notifications_send','');
 INSERT INTO users_permission_definitions (`key`,`category`) VALUES ('objects','');
 INSERT INTO users_permission_definitions (`key`,`category`) VALUES ('objectbricks','');
-INSERT INTO users_permission_definitions (`key`,`category`) VALUES ('piwik_reports','');
-INSERT INTO users_permission_definitions (`key`,`category`) VALUES ('piwik_settings','');
 INSERT INTO users_permission_definitions (`key`,`category`) VALUES ('plugins','');
 INSERT INTO users_permission_definitions (`key`,`category`) VALUES ('plugin_cmf_perm_activityview','');
 INSERT INTO users_permission_definitions (`key`,`category`) VALUES ('plugin_cmf_perm_customerview','');


### PR DESCRIPTION
Related to https://github.com/pimcore/pimcore/pull/7320 and https://github.com/pimcore/pimcore/pull/8216