### PR TITLE
Avoid integrity constraint violation on translations_admin table

### DIFF
--- a/dump/data-1-translations_admin.sql
+++ b/dump/data-1-translations_admin.sql
@@ -742,9 +742,6 @@ INSERT INTO translations_admin (`key`,`type`,`language`,`text`,`creationDate`,`m
 INSERT INTO translations_admin (`key`,`type`,`language`,`text`,`creationDate`,`modificationDate`,`userOwner`,`userModification`) VALUES ('PIM','simple','tr','',1719850132,1719850132,2,2);
 INSERT INTO translations_admin (`key`,`type`,`language`,`text`,`creationDate`,`modificationDate`,`userOwner`,`userModification`) VALUES ('PIM','simple','uk','',1719850132,1719850132,2,2);
 INSERT INTO translations_admin (`key`,`type`,`language`,`text`,`creationDate`,`modificationDate`,`userOwner`,`userModification`) VALUES ('PIM','simple','zh_Hans','',1719850132,1719850132,2,2);
-INSERT INTO translations_admin (`key`,`type`,`language`,`text`,`creationDate`,`modificationDate`,`userOwner`,`userModification`) VALUES ('Pimcore\'s logotype','simple','de','',1719850077,1719850077,0,0);
-INSERT INTO translations_admin (`key`,`type`,`language`,`text`,`creationDate`,`modificationDate`,`userOwner`,`userModification`) VALUES ('Pimcore\'s logotype','simple','en','',1719850077,1719850077,0,0);
-INSERT INTO translations_admin (`key`,`type`,`language`,`text`,`creationDate`,`modificationDate`,`userOwner`,`userModification`) VALUES ('Pimcore\'s logotype','simple','fr','',1719850077,1719850077,0,0);
 INSERT INTO translations_admin (`key`,`type`,`language`,`text`,`creationDate`,`modificationDate`,`userOwner`,`userModification`) VALUES ('Portal-Page','simple','ca','',1719850132,1719850132,2,2);
 INSERT INTO translations_admin (`key`,`type`,`language`,`text`,`creationDate`,`modificationDate`,`userOwner`,`userModification`) VALUES ('Portal-Page','simple','cs','',1719850132,1719850132,2,2);
 INSERT INTO translations_admin (`key`,`type`,`language`,`text`,`creationDate`,`modificationDate`,`userOwner`,`userModification`) VALUES ('Portal-Page','simple','de','',1719850132,1719850132,2,2);


### PR DESCRIPTION
The installer will sometimes produce exceptions like this because the admin translation key from the login form is already in the table:

![image](https://github.com/pimcore/demo/assets/4639428/9a5edac0-77d9-49f1-9fac-7891336ede6d)

Therefore this is removed from the dump now.